### PR TITLE
render selected plot for export offscreen

### DIFF
--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -1,4 +1,5 @@
 import os
+import time
 from pathlib import Path
 from traitlets import Bool, List, Unicode, observe
 from glue_jupyter.bqplot.image import BqplotImageView
@@ -23,7 +24,6 @@ except ImportError:
     HAS_OPENCV = False
 else:
     import threading
-    import time
     HAS_OPENCV = True
 
 __all__ = ['Export']
@@ -300,7 +300,12 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
                 filename = Path(filename).expanduser()
             else:
                 filename = None
-            self.save_figure(plot, filename, filetype, show_dialog=show_dialog)
+
+            with plot._plugin.as_active():
+                # NOTE: could still take some time for the plot itself to update,
+                # for now we'll hardcode a short amount of time for the plot to render any updates
+                time.sleep(0.2)
+                self.save_figure(plot, filename, filetype, show_dialog=show_dialog)
 
         elif len(self.table.selected):
             filetype = self.table_format.selected

--- a/jdaviz/configs/default/plugins/export/export.vue
+++ b/jdaviz/configs/default/plugins/export/export.vue
@@ -177,6 +177,10 @@
         :single_select_allow_blank="false"
       >
       </plugin-inline-select>
+      <jupyter-widget 
+          v-if='plot_selected_widget.length > 0'
+          style="position: absolute; left: -100%"
+          :widget="plot_selected_widget"/> 
       <v-row v-if="plot_selected.length > 0" class="row-min-bottom-padding">
         <v-select
           :menu-props="{ left: true }"

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -2589,6 +2589,7 @@ class PluginPlotSelect(SelectPluginComponent):
 class PluginPlotSelectMixin(VuetifyTemplate, HubListener):
     plot_items = List().tag(sync=True)
     plot_selected = Any().tag(sync=True)
+    plot_selected_widget = Any().tag(sync=True)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -2596,6 +2597,15 @@ class PluginPlotSelectMixin(VuetifyTemplate, HubListener):
                                      'plot_items',
                                      'plot_selected',
                                      multiselect='multiselect' if hasattr(self, 'multiselect') else None)  # noqa
+
+    @observe('plot_selected')
+    def _plot_selected_changed(self, *args):
+        if not hasattr(self, 'plot'):
+            return
+        if self.plot_selected == '':
+            self.plot_selected_widget = ''
+        else:
+            self.plot_selected_widget = f'IPY_MODEL_{self.plot.selected_obj._obj.model_id}'
 
 
 class DatasetSpectralSubsetValidMixin(VuetifyTemplate, HubListener):


### PR DESCRIPTION
This pull request addresses the issue where exporting figure widgets not rendered to screen fails by:
* rendering the selected plugin plot offscreen
* ensuring the plot's plugin is considered active when clicking the export button 
* giving a small amount of time to ensure that the plot can update (but this is hardcoded and may not always be sufficient)


This "solution" still will not catch the case where the API is used to export a plot, but that same issue is known for the viewer plots as well and was present in the original export plot plugin.