### PR TITLE
Bugfix: re-enable transparency in DQ colormap

### DIFF
--- a/jdaviz/configs/default/plugins/data_quality/data_quality.py
+++ b/jdaviz/configs/default/plugins/data_quality/data_quality.py
@@ -214,37 +214,22 @@ class DataQuality(PluginTemplateMixin, ViewerSelectMixin):
         dq_layers = self.get_dq_layers(viewers=viewers)
 
         for dq_layer in dq_layers:
-            dq_layer.composite._allow_bad_alpha = True
-
-            # for cubeviz, also change uncert-viewer defaults to
-            # map the out-of-bounds regions to the cmap's `bad` color:
-            if self.app.config in ('cubeviz', 'rampviz'):
-                viewer = self.app.get_viewer(
-                    getattr(
-                        self.app._jdaviz_helper,
-                        '_default_uncert_viewer_reference_name', 'level-2'
-                    )
-                )
-
-                for layer in viewer.layers:
-                    # allow bad alpha for image layers, not subsets:
-                    if not hasattr(layer, 'subset_array'):
-                        layer.composite._allow_bad_alpha = True
-                        layer.force_update()
-
             flag_bits = np.array([flag['flag'] for flag in self.decoded_flags])
 
             dq_layer.state.stretch = 'lookup'
             stretch_object = dq_layer.state.stretch_object
             stretch_object.flags = flag_bits
 
-            with delay_callback(dq_layer.state, 'alpha', 'cmap', 'v_min', 'v_max'):
+            with delay_callback(dq_layer.state, 'alpha', 'cmap', 'v_min', 'v_max', 'cmap_bad'):
                 if len(flag_bits):
                     dq_layer.state.v_min = min(flag_bits)
                     dq_layer.state.v_max = max(flag_bits)
 
                 dq_layer.state.alpha = self.dq_layer_opacity
                 dq_layer.state.cmap = cmap
+
+                # make un-flagged pixels in DQ array transparent:
+                dq_layer.state.cmap_bad = (0, 0, 0, 0)
 
     def get_dq_layers(self, viewers=None):
         if self.dq_layer_selected == '':


### PR DESCRIPTION
Since way back in https://github.com/spacetelescope/jdaviz/pull/2817, DQ layers have been rendered with transparent pixels using a temporary private API in glue. As of glue-core 1.24.0, the old private API isn't used anymore, and there's a public API added in https://github.com/glue-viz/glue/pull/2556. As a result, the DQ layer's unflagged pixels aren't transparent.

This PR updates the transparency setting logic to restore transparent unflagged pixels in DQ layers.

I've checked that this works on imviz and cubeviz.

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
